### PR TITLE
Navigation JobListView to JobDetailView

### DIFF
--- a/src/App/ViewModels/JobDetailViewModel.cs
+++ b/src/App/ViewModels/JobDetailViewModel.cs
@@ -18,11 +18,11 @@ namespace App.ViewModels
         public JobDetailViewModel(string Link)
         {
 
-            new Action(async () => await LoadData(Link))();
+            new Action(async () => await LoadDataAsync(Link))();
 
             OpenJobWebURLCommand = new Command<string>(OpenJobWebURL);
         }
-        public async Task LoadData(string link)
+        public async Task LoadDataAsync(string link)
         {
 
             var Data = await AppConstant.ApiUrl

--- a/src/App/ViewModels/JobDetailViewModel.cs
+++ b/src/App/ViewModels/JobDetailViewModel.cs
@@ -15,18 +15,18 @@ namespace App.ViewModels
         public JobDetailModel JobsDetail { get; set; }
         public Command OpenJobWebURLCommand { get; set; }
 
-        public JobDetailViewModel()
+        public JobDetailViewModel(string Link)
         {
 
-            new Action(async () => await LoadData())();
+            new Action(async () => await LoadData(Link))();
 
             OpenJobWebURLCommand = new Command<string>(OpenJobWebURL);
         }
-        public async Task LoadData()
+        public async Task LoadData(string link)
         {
 
             var Data = await AppConstant.ApiUrl
-            .AppendPathSegment(AppConstant.ApiEndPoint+"/detail/1238")
+            .AppendPathSegment(AppConstant.ApiEndPoint+"/detail/"+link)
             .WithHeader("Ocp-Apim-Subscription-Key", AppConstant.AppSecrets)
             .GetJsonAsync<JobDetailModel>();
 

--- a/src/App/ViewModels/JobsListViewModel.cs
+++ b/src/App/ViewModels/JobsListViewModel.cs
@@ -23,12 +23,12 @@ namespace App.ViewModels
         {
             this.Navigation = navshell;
             CallDetailScreenCommand = new Command<string>(async (string Link) => await OpenDetailView(Link));
-            new Action(async () => await LoadData())();
+            new Action(async () => await LoadDataAsync())();
 
             
         }
 
-        public async Task LoadData()
+        public async Task LoadDataAsync()
         {
             
             var Cards = await AppConstant.ApiUrl

--- a/src/App/ViewModels/JobsListViewModel.cs
+++ b/src/App/ViewModels/JobsListViewModel.cs
@@ -22,7 +22,7 @@ namespace App.ViewModels
         public JobsListViewModel(INavigation navshell)
         {
             this.Navigation = navshell;
-            CallDetailScreenCommand = new Command<string>(async (string Link) => await OpenDetailView(Link));
+            CallDetailScreenCommand = new Command<string>(async (string Link) => await OpenDetailViewAsync(Link));
             new Action(async () => await LoadDataAsync())();
 
             
@@ -40,7 +40,7 @@ namespace App.ViewModels
 
         }
 
-        public async Task OpenDetailView(string link) {
+        public async Task OpenDetailViewAsync(string link) {
             
             await Navigation.PushAsync(new JobDetailView(link));
         

--- a/src/App/ViewModels/JobsListViewModel.cs
+++ b/src/App/ViewModels/JobsListViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using App.Models;
 using App.Services;
+using App.Views;
 using Flurl;
 using Flurl.Http;
 using System;
@@ -16,10 +17,15 @@ namespace App.ViewModels
     {
         //public AppConstant ServiceConstant = new AppConstant();
         public JobListModel JobsList { get; set; }
-        public JobsListViewModel()
+        public Command CallDetailView { get; set; }
+        public INavigation Navigation { get; set; }
+        public JobsListViewModel(INavigation navshell)
         {
-
+            this.Navigation = navshell;
+            CallDetailView = new Command<string>(async (string Link) => await OpenDetailView(Link));
             new Action(async () => await LoadData())();
+
+            
         }
 
         public async Task LoadData()
@@ -32,6 +38,12 @@ namespace App.ViewModels
                 .GetJsonAsync<JobListModel>();
             JobsList = Cards;
 
+        }
+
+        public async Task OpenDetailView(string link) {
+            
+            await Navigation.PushAsync(new JobDetailView(link));
+        
         }
         public event PropertyChangedEventHandler PropertyChanged;
     }

--- a/src/App/ViewModels/JobsListViewModel.cs
+++ b/src/App/ViewModels/JobsListViewModel.cs
@@ -17,12 +17,12 @@ namespace App.ViewModels
     {
         //public AppConstant ServiceConstant = new AppConstant();
         public JobListModel JobsList { get; set; }
-        public Command CallDetailView { get; set; }
+        public Command CallDetailScreenCommand { get; set; }
         public INavigation Navigation { get; set; }
         public JobsListViewModel(INavigation navshell)
         {
             this.Navigation = navshell;
-            CallDetailView = new Command<string>(async (string Link) => await OpenDetailView(Link));
+            CallDetailScreenCommand = new Command<string>(async (string Link) => await OpenDetailView(Link));
             new Action(async () => await LoadData())();
 
             

--- a/src/App/Views/JobDetailView.xaml
+++ b/src/App/Views/JobDetailView.xaml
@@ -41,9 +41,7 @@
         </ResourceDictionary>
     </ContentPage.Resources>
 
-    <ContentPage.BindingContext>
-        <Local:JobDetailViewModel/>
-    </ContentPage.BindingContext>
+    
 
  <ScrollView>
     <StackLayout >

--- a/src/App/Views/JobDetailView.xaml.cs
+++ b/src/App/Views/JobDetailView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using App.ViewModels;
+using System;
 using System.Collections.Generic;
 using Xamarin.Forms;
 
@@ -6,10 +7,10 @@ namespace App.Views
 {
     public partial class JobDetailView : ContentPage
     {
-        public JobDetailView()
+        public JobDetailView(string link)
         {
             InitializeComponent();
-
+            BindingContext = new JobDetailViewModel(link);
         }
     }
 }

--- a/src/App/Views/JosbListView.xaml
+++ b/src/App/Views/JosbListView.xaml
@@ -9,12 +9,11 @@
              x:Class="App.Views.JosbListView"
              xmlns:Local="clr-namespace:App.ViewModels"
              Shell.NavBarIsVisible="True"
+             x:Name="JobListView"
              BackgroundColor="{StaticResource BackGroundColor}"
              >
         
-    <ContentPage.BindingContext>
-        <Local:JobsListViewModel />
-    </ContentPage.BindingContext>
+    
     <ContentPage.Content>
 
         <StackLayout Padding="20,20,20,0">
@@ -46,8 +45,11 @@
                             <Frame CornerRadius="4" BackgroundColor="{StaticResource CardBackGroundColor}" Margin="5,0,0,5"
                                    Padding="10,10"
                                    HasShadow="False" >
+                                
                                 <Grid HorizontalOptions="FillAndExpand" BackgroundColor="{StaticResource CardBackGroundColor}">
-
+                                    <Grid.GestureRecognizers>
+                                        <TapGestureRecognizer NumberOfTapsRequired="1" Command="{Binding Source={x:Reference Name=JobListView},Path=BindingContext.CallDetailView}" CommandParameter="{Binding Link}"/>
+                                    </Grid.GestureRecognizers>
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>

--- a/src/App/Views/JosbListView.xaml
+++ b/src/App/Views/JosbListView.xaml
@@ -48,7 +48,7 @@
                                 
                                 <Grid HorizontalOptions="FillAndExpand" BackgroundColor="{StaticResource CardBackGroundColor}">
                                     <Grid.GestureRecognizers>
-                                        <TapGestureRecognizer NumberOfTapsRequired="1" Command="{Binding Source={x:Reference Name=JobListView},Path=BindingContext.CallDetailView}" CommandParameter="{Binding Link}"/>
+                                        <TapGestureRecognizer NumberOfTapsRequired="1" Command="{Binding Source={x:Reference Name=JobListView},Path=BindingContext.CallDetailScreenCommand}" CommandParameter="{Binding Link}"/>
                                     </Grid.GestureRecognizers>
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>

--- a/src/App/Views/JosbListView.xaml.cs
+++ b/src/App/Views/JosbListView.xaml.cs
@@ -1,3 +1,4 @@
+using App.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace App.Views
         public JosbListView()
         {
             InitializeComponent();
-            
+            BindingContext = new JobsListViewModel(Navigation);
         }
     }
 }


### PR DESCRIPTION
## Navigation to from JobListView to JobDetailWiew - Ref #27 ##

• Remove BindingContext from XAML file, it was assigned in the back end in the cs files from JobsListView and JobDetailView 
• Send Job Link Parameter from JobsListView to JobDetailView


### Ways to assign ViewModel to BindingContext in the Back End File ###
```md
BindingContext = new MyViewModel(<ParamToSend>);
```

### Visual aids ###

| Preview| 
|---|
|![navigationlistview](https://user-images.githubusercontent.com/23615129/71951561-775c6780-31a9-11ea-8204-22b260dbaaf7.gif)|